### PR TITLE
feat: [AXM-2286] add new field to ContentDate, pass user to create UserDate

### DIFF
--- a/edx_when/api.py
+++ b/edx_when/api.py
@@ -553,6 +553,7 @@ def update_or_create_assignments_due_dates(course_key, assignments: list[_Assign
             location=assignment.block_key,
             field='due',
             block_type=assignment.assignment_type,
+            contains_gated_content=assignment.contains_gated_content,
             defaults={
                 'policy': models.DatePolicy.objects.get_or_create(abs_date=assignment.date)[0],
                 'assignment_title': assignment.title,

--- a/edx_when/api.py
+++ b/edx_when/api.py
@@ -81,11 +81,12 @@ def is_enabled_for_course(course_key):
     return models.ContentDate.objects.filter(course_id=course_key, active=True).exists()
 
 
-def set_dates_for_course(course_key, items):
+def set_dates_for_course(course_key, items, user=None):
     """
     Set dates for blocks.
 
     items: iterator of (location, field metadata dictionary)
+    user: user object to set dates for
     """
     with transaction.atomic():
         active_date_ids = []
@@ -97,7 +98,7 @@ def set_dates_for_course(course_key, items):
                     if val:
                         log.info('Setting date for %r, %s, %r', location, field, val)
                         active_date_ids.append(
-                            set_date_for_block(course_key, location, field, val)
+                            set_date_for_block(course_key, location, field, val, user)
                         )
 
         # Now clear out old dates that we didn't touch

--- a/edx_when/models.py
+++ b/edx_when/models.py
@@ -170,6 +170,13 @@ class UserDate(TimeStampedModel):
         """
         return self.content_date.location
 
+    @property
+    def learner_has_access(self):
+        """
+        Return a boolean indicating whether the piece of content is accessible to the learner.
+        """
+        return not self.is_content_gated
+
     def clean(self):
         """
         Validate data before saving.


### PR DESCRIPTION
**Summary**
This PR makes two modifications:

- adds a new field on `ContentDate` model which is required by the user dates API
- makes sure user is available when creating `UserDate` instances

**Required by:**
[https://github.com/raccoongang/edx-platform/pull/2669](https://github.com/raccoongang/edx-platform/pull/2669)

> [!note]
Related to:
https://github.com/raccoongang/edx-platform/pull/2672
https://github.com/raccoongang/edx-when/pull/7